### PR TITLE
Validation script to handle unsorted results and all results

### DIFF
--- a/src/main/java/dev/morling/onebrc/ValidateResult.java
+++ b/src/main/java/dev/morling/onebrc/ValidateResult.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2023 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.onebrc;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ValidateResult {
+
+    private static HashMap<String, String> parseOutputStringToMap(String s) {
+        HashMap<String, String> map = new HashMap<>();
+
+        String regex = "\\b([\\p{L}.'\\-() ,]*)=([\\d./-]+)";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(s);
+        while (matcher.find()) {
+            String key = matcher.group(1).trim();
+            String value = matcher.group(2).trim();
+
+            if (key.startsWith(", ")) {
+                key = key.substring(2);
+            }
+            map.put(key, value);
+        }
+
+        return map;
+    }
+
+    public static void main(String[] args) throws IOException {
+        HashMap<String, String> expected = parseOutputStringToMap(args[0]);
+        HashMap<String, String> actual = parseOutputStringToMap(args[1]);
+
+        AtomicLong count = new AtomicLong();
+        if (!expected.equals(actual)) {
+            expected.forEach((key, expectedValue) -> {
+                if (actual.containsKey(key)) {
+                    String actualValue = actual.get(key);
+                    if (!expectedValue.equals(actualValue)) {
+                        System.out.println(key + ", Expected: " + expectedValue + ", Actual: " + actualValue);
+                        count.getAndIncrement();
+                    }
+                }
+                else {
+                    count.getAndIncrement();
+                    System.out.println("Key: " + key + "does not exist in actual.");
+                }
+            });
+        }
+        System.out.println("Correct Stations: " + (expected.keySet().size() - count.get()) + "/" + expected.keySet().size());
+        System.out.println("Solution Correctness: " + String.format("%.2f", (expected.keySet().size() - count.get()) * 100.0 / expected.keySet().size()) + "%.");
+    }
+}

--- a/validate_result.sh
+++ b/validate_result.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+JAVA_OPTS=""
+if [ ! -f measurements_baseline_results.txt ]; then
+  EXPECTED=$(java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_baseline)
+  echo "$EXPECTED" > measurements_baseline_results.txt
+else
+  EXPECTED=$(cat measurements_baseline_results.txt)
+fi
+
+ACTUAL=$(java $JAVA_OPTS --enable-preview --class-path target/average-1.0.0-SNAPSHOT.jar "$1")
+java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.ValidateResult "$EXPECTED" "$ACTUAL"


### PR DESCRIPTION
I had written a validation script before knowing that such a script already existed upstream (https://github.com/gunnarmorling/1brc/blob/main/test.sh), but I noticed that the current testing would require both the ordering of the keys in the end maps of the fork to be the same as the main.

If desirable and my understanding is correct I can incorporate my script into the existing `test.sh` as my script might help determine the correctness of solutions that do not use an ordered map to store results. Additionally, this script also will check the full output and not just a sample. 